### PR TITLE
Add full-screen hero carousel

### DIFF
--- a/hero-carousel.js
+++ b/hero-carousel.js
@@ -1,0 +1,10 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const heroCarousel = document.querySelector('#heroCarousel');
+  if (heroCarousel) {
+    new bootstrap.Carousel(heroCarousel, {
+      interval: 5000,
+      ride: 'carousel',
+      pause: false
+    });
+  }
+});

--- a/index.html
+++ b/index.html
@@ -47,20 +47,63 @@
   </nav>
 
   <!-- HERO -->
-  <section id="inicio" class="hero d-flex align-items-center justify-content-center text-center text-white" style="background: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)), url('assets/Noviembre/NOVIEMBRE/RPZ09975.jpg') center/cover no-repeat fixed;">
-    <div class="overlay"></div>
-    <div class="container position-relative">
-      <div class="row justify-content-center">
-        <div class="col-lg-8" data-aos="fade-up" data-aos-duration="1000">
-          <!--<img src="assets/logo.png" alt="Agreste" class="img-fluid mb-4" style="max-width: 300px;">-->
-          <h1 class="display-4 fw-bold">Madera que inspira, calidad que perdura</h1>
-          <p class="lead">Diseñamos piezas únicas, contigo en cada paso</p>
-          <div class="mt-4">
-            <a href="#contacto" class="btn btn-outline-light btn-lg me-2"><i class="fas fa-envelope me-2"></i>Contáctanos</a>
-            <a href="#proyectos" class="btn btn-custom btn-lg"><i class="fas fa-eye me-2"></i>Ver proyectos</a>
+  <section id="inicio" class="hero-carousel">
+    <div id="heroCarousel" class="carousel slide carousel-fade" data-bs-ride="carousel">
+      <div class="carousel-inner">
+        <div class="carousel-item active hero" style="background-image: url('assets/Noviembre/NOVIEMBRE/RPZ09975.jpg');">
+          <div class="overlay"></div>
+          <div class="container position-relative">
+            <div class="row justify-content-center">
+              <div class="col-lg-8" data-aos="fade-up" data-aos-duration="1000">
+                <h1 class="display-4 fw-bold">Madera que inspira, calidad que perdura</h1>
+                <p class="lead">Diseñamos piezas únicas, contigo en cada paso</p>
+                <div class="mt-4">
+                  <a href="#contacto" class="btn btn-outline-light btn-lg me-2"><i class="fas fa-envelope me-2"></i>Contáctanos</a>
+                  <a href="#proyectos" class="btn btn-custom btn-lg"><i class="fas fa-eye me-2"></i>Ver proyectos</a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="carousel-item hero" style="background-image: url('assets/ImagenesParaUsar/1 (6).jpg');">
+          <div class="overlay"></div>
+          <div class="container position-relative">
+            <div class="row justify-content-center">
+              <div class="col-lg-8">
+                <h1 class="display-4 fw-bold">Artesanía que transforma espacios</h1>
+                <p class="lead">Creaciones únicas adaptadas a tu estilo</p>
+                <div class="mt-4">
+                  <a href="#contacto" class="btn btn-outline-light btn-lg me-2"><i class="fas fa-envelope me-2"></i>Contáctanos</a>
+                  <a href="#servicios" class="btn btn-custom btn-lg"><i class="fas fa-cogs me-2"></i>Nuestros servicios</a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="carousel-item hero" style="background-image: url('assets/Agosto/AGOSTO/_A7_6051.jpg');">
+          <div class="overlay"></div>
+          <div class="container position-relative">
+            <div class="row justify-content-center">
+              <div class="col-lg-8">
+                <h1 class="display-4 fw-bold">Innovación en madera</h1>
+                <p class="lead">Proyectos personalizados para cada necesidad</p>
+                <div class="mt-4">
+                  <a href="#contacto" class="btn btn-outline-light btn-lg me-2"><i class="fas fa-envelope me-2"></i>Contáctanos</a>
+                  <a href="#proyectos" class="btn btn-custom btn-lg"><i class="fas fa-eye me-2"></i>Ver proyectos</a>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
+      <button class="carousel-control-prev" type="button" data-bs-target="#heroCarousel" data-bs-slide="prev">
+        <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+        <span class="visually-hidden">Previous</span>
+      </button>
+      <button class="carousel-control-next" type="button" data-bs-target="#heroCarousel" data-bs-slide="next">
+        <span class="carousel-control-next-icon" aria-hidden="true"></span>
+        <span class="visually-hidden">Next</span>
+      </button>
     </div>
   </section>
 
@@ -754,14 +797,16 @@
   <!-- Botón de regreso arriba -->
   <a href="#" class="back-to-top"><i class="fas fa-arrow-up"></i></a>
   
-  <!-- Bootstrap JS -->
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-  <!-- AOS Animation Library -->
-  <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
-  <!-- Custom JS -->
-  <script>
-    // Inicializar AOS
-    AOS.init();
+    <!-- Bootstrap JS -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <!-- AOS Animation Library -->
+    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+    <!-- Hero Carousel JS -->
+    <script src="hero-carousel.js"></script>
+    <!-- Custom JS -->
+    <script>
+      // Inicializar AOS
+      AOS.init();
     
     // Navbar scroll
     window.addEventListener('scroll', function() {

--- a/style.css
+++ b/style.css
@@ -74,7 +74,6 @@ body {
 
 /* Hero Section */
 .hero {
-  background: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)), url('assets/AgresteTransparente.png') center/cover no-repeat fixed;
   height: 100vh;
   display: flex;
   align-items: center;
@@ -82,6 +81,9 @@ body {
   text-align: center;
   position: relative;
   color: var(--text-color);
+  background-size: cover;
+  background-position: center;
+  transition: var(--transition);
 }
 
 .hero .overlay {
@@ -90,7 +92,9 @@ body {
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.6);
+  background-color: var(--primary-color);
+  opacity: 0.55;
+  transition: var(--transition);
 }
 
 .hero h1 {
@@ -104,6 +108,17 @@ body {
   font-size: 1.25rem;
   margin-bottom: 2rem;
   text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.5);
+}
+
+/* Hero Carousel */
+.hero-carousel .carousel-item {
+  height: 100vh;
+  transition: opacity 1s ease-in-out;
+}
+
+.hero-carousel .carousel-control-prev-icon,
+.hero-carousel .carousel-control-next-icon {
+  filter: invert(1);
 }
 
 /* Buttons */


### PR DESCRIPTION
## Summary
- replace the static hero section with a Bootstrap carousel featuring three full-height slides
- style carousel overlays and transitions using existing CSS variables for colors
- introduce `hero-carousel.js` to initialize the slider externally

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5cd854948330948bc2a9d92f8714